### PR TITLE
Flow for isLoggedIn and Loading state in RecipesFragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
-    implementation("com.google.android.material:material:1.4.0")
+    implementation("com.google.android.material:material:1.6.1")
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.fragments)

--- a/app/src/main/java/com/example/myapplication/CredentialsManager.kt
+++ b/app/src/main/java/com/example/myapplication/CredentialsManager.kt
@@ -5,7 +5,7 @@ import android.content.Context
 object CredentialsManager {
 
     private const val PREFS_NAME = "user_prefs"
-    private const val KEY_IS_LOGGED_IN = "is_logged_in"
+    private const val KEY_LOGGED_IN = "logged_in"
     private const val KEY_EMAIL = "email"
     private const val KEY_PASSWORD = "password"
 
@@ -55,15 +55,6 @@ object CredentialsManager {
     private fun getSharedPreferences(context: Context) =
         context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
-    fun isLoggedIn(context: Context): Boolean {
-        return getSharedPreferences(context).getBoolean(KEY_IS_LOGGED_IN, false)
-    }
-
-    fun setLoggedIn(context: Context, isLoggedIn: Boolean) {
-        getSharedPreferences(context).edit()
-            .putBoolean(KEY_IS_LOGGED_IN, isLoggedIn)
-            .apply()
-    }
 
     fun saveUserCredentials(context: Context, email: String, password: String) {
         getSharedPreferences(context).edit()
@@ -91,5 +82,17 @@ object CredentialsManager {
                 isValidPhoneNumber(phoneNumber) &&
                 isValidPassword(password) &&
                 isTermsAccepted
+    }
+
+    fun setLoggedIn(context: Context, isLoggedIn: Boolean) {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+        editor.putBoolean(KEY_LOGGED_IN, isLoggedIn)
+        editor.apply()
+    }
+
+    fun isLoggedIn(context: Context): Boolean {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return sharedPreferences.getBoolean(KEY_LOGGED_IN, false)
     }
 }

--- a/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -8,13 +8,12 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.SearchView
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 
 class MainActivity : AppCompatActivity() {
 
@@ -27,33 +26,33 @@ class MainActivity : AppCompatActivity() {
 
         if (CredentialsManager.isLoggedIn(this)) {
             loadMainContent()
-            setupSearchView()
         } else {
             if (savedInstanceState == null) {
                 navigateToCreateAccountFragment()
             }
         }
-
-        setupLogoutButton()
+        //setupLogoutButton()
     }
 
     private fun loadMainContent() {
-        val recyclerView: RecyclerView = findViewById(R.id.recyclerView)
-        recyclerView.layoutManager = LinearLayoutManager(this)
-
         recipeAdapter = RecipeAdapter(
             recipes = emptyList(),
-            itemClickListener = { recipe ->
-                openRecipeDetail(recipe)
-            },
+            itemClickListener = { recipe -> openRecipeDetail(recipe) },
             likeClickListener = { recipe ->
-                Toast.makeText(this, "Liked: ${recipe.title}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    this,
+                    "Liked: ${recipe.title}",
+                    Toast.LENGTH_SHORT
+                ).show()
             },
             shareClickListener = { recipe ->
-                Toast.makeText(this, "Shared: ${recipe.title}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    this,
+                    "Shared: ${recipe.title}",
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         )
-        recyclerView.adapter = recipeAdapter
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -73,34 +72,19 @@ class MainActivity : AppCompatActivity() {
         startActivity(intent)
     }
 
-    private fun setupLogoutButton() {
+/*    private fun setupLogoutButton() {
         val logoutButton: Button = findViewById(R.id.logoutButton)
         logoutButton.setOnClickListener {
             CredentialsManager.setLoggedIn(this, false)
             navigateToCreateAccountFragment()
-
             findViewById<RecyclerView>(R.id.recyclerView).visibility = View.GONE
             logoutButton.visibility = View.GONE
         }
-    }
+    }*/
 
     private fun navigateToCreateAccountFragment() {
         supportFragmentManager.beginTransaction()
             .replace(R.id.fragmentContainerView, CreateAccountFragment())
             .commit()
-    }
-
-    private fun setupSearchView() {
-        val searchView = findViewById<SearchView>(R.id.searchView)
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String?): Boolean {
-                return false
-            }
-
-            override fun onQueryTextChange(newText: String?): Boolean {
-                recipesViewModel.filterRecipes(newText.orEmpty())
-                return true
-            }
-        })
     }
 }

--- a/app/src/main/java/com/example/myapplication/RecipesFragment.kt
+++ b/app/src/main/java/com/example/myapplication/RecipesFragment.kt
@@ -1,0 +1,148 @@
+package com.example.myapplication
+
+import RecipeAdapter
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.Button
+import androidx.appcompat.widget.SearchView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.progressindicator.CircularProgressIndicator
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class RecipesFragment : Fragment(R.layout.fragment_recipes) {
+
+    private lateinit var recipeAdapter: RecipeAdapter
+    private val recipesViewModel: RecipesViewModel by viewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        Log.d("RecipesFragment", "Fragment view created")
+
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                recipesViewModel.uiState.collect { uiState ->
+                    Log.d("RecipesFragment", "UIState collected: $uiState")
+                    withContext(Dispatchers.Main) {
+                        updateUIState(uiState)
+                    }
+                }
+            }
+        }
+
+
+        setupLogoutButton(view)
+
+        loadMainContent(view)
+
+    }
+
+    private fun setupLogoutButton(view: View) {
+        val logoutButton: Button = view.findViewById(R.id.logoutButton)
+        logoutButton.setOnClickListener {
+            CredentialsManager.setLoggedIn(requireContext(), false)
+            navigateToCreateAccountFragment()
+            view.findViewById<RecyclerView>(R.id.recyclerView).visibility = View.GONE
+            logoutButton.visibility = View.GONE
+        }
+    }
+
+    private fun navigateToCreateAccountFragment() {
+        activity?.supportFragmentManager?.beginTransaction()
+            ?.replace(R.id.fragmentContainerView, CreateAccountFragment())
+            ?.commitAllowingStateLoss()
+    }
+
+    private fun loadMainContent(view: View) {
+        val recyclerView: RecyclerView = view.findViewById(R.id.recyclerView)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+
+        recipeAdapter = RecipeAdapter(
+            recipes = emptyList(),
+            itemClickListener = { recipe -> openRecipeDetail(recipe) },
+            likeClickListener = { recipe ->
+                Toast.makeText(requireContext(), "Liked: ${recipe.title}", Toast.LENGTH_SHORT)
+                    .show()
+            },
+            shareClickListener = { recipe ->
+                Toast.makeText(requireContext(), "Shared: ${recipe.title}", Toast.LENGTH_SHORT)
+                    .show()
+            }
+        )
+
+        recyclerView.adapter = recipeAdapter
+
+        val searchView: SearchView = view.findViewById(R.id.search_view)
+        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+            override fun onQueryTextSubmit(query: String?): Boolean {
+                query?.let {
+                    recipesViewModel.updateSearchQuery(it)
+                }
+                return true
+            }
+
+            override fun onQueryTextChange(newText: String?): Boolean {
+                newText?.let {
+                    recipesViewModel.updateSearchQuery(it)
+                }
+                return true
+            }
+        })
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                recipesViewModel.recipes.collect { updatedRecipes ->
+                    recipeAdapter.updateRecipes(updatedRecipes)
+                }
+            }
+        }
+    }
+
+    private fun openRecipeDetail(recipe: Recipe) {
+        val intent = Intent(requireContext(), RecipeDetailActivity::class.java).apply {
+            putExtra("RECIPE_ID", recipe.id)
+            putExtra("RECIPE_TITLE", recipe.title)
+            putExtra("RECIPE_IMAGE", recipe.imageResId)
+        }
+        startActivity(intent)
+    }
+
+    private fun updateUIState(state: RecipesUiState) {
+        view?.let { view ->
+            val progressIndicator: CircularProgressIndicator =
+                view.findViewById(R.id.circularProgressIndicator)
+            /*val progressIndicator: CircularProgressIndicator =
+                view.findViewById(R.id.circularProgressIndicator)
+            progressIndicator.visibility = View.VISIBLE*/
+            when (state) {
+                is RecipesUiState.Loading -> {
+                    Log.d("RecipesFragment", "Setting progress indicator to visible")
+                    progressIndicator.visibility = View.VISIBLE
+                }
+
+                is RecipesUiState.Success -> {
+                    Log.d("RecipesFragment", "Setting progress indicator to gone")
+                    progressIndicator.visibility = View.GONE
+                    recipeAdapter.updateRecipes(state.recipes)
+                }
+
+                is RecipesUiState.Error -> {
+                    Log.d("RecipesFragment", "Setting progress indicator to gone")
+                    progressIndicator.visibility = View.GONE
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,39 +10,9 @@
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/fragmentContainerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
-
-    <androidx.appcompat.widget.SearchView
-        android:id="@+id/searchView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="1dp"
-        android:queryHint="Search Recipes"
-        android:iconifiedByDefault="false"
-        android:background="@android:color/white"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/searchView"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/logoutButton"
-        tools:listitem="@layout/item_recipe" />
-
-    <Button
-        android:id="@+id/logoutButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/Logout"
-        android:layout_marginStart="300dp"
-        android:layout_marginBottom="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:layout_height="match_parent"
+        android:name="com.example.myapplication.RecipesFragment"
+        android:layout_marginTop="56dp"
+        tools:layout="@layout/fragment_recipes" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_recipes.xml
+++ b/app/src/main/res/layout/fragment_recipes.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".RecipesFragment">
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/circularProgressIndicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:indicatorSize="72dp"
+        android:visibility="gone"
+        app:trackThickness="6dp"
+        app:backgroundTint="#ff0000"
+        app:indicatorColor="#00ff00"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.appcompat.widget.SearchView
+        android:id="@+id/search_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:queryHint="Search recipes"
+        android:iconifiedByDefault="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/search_view"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/logoutButton" />
+
+    <Button
+        android:id="@+id/logoutButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/Logout"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="16dp" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- RecipesFragment now displays a circular ProgressIndicator when the fragment starts, and after 1 second, the results are loaded and displayed.
- Each time the user changes the search query, a loading state is shown, hiding recipes for 1 second.
- UIState is emitted only once after a finished query, waiting for 300ms to detect the typing stop.
- The logout button in RecipesFragment now navigates back to the LoginFragment.
- ViewModel emits UIState objects containing the current recipes or loading state.
- CredentialsManager manages the login state as a flow.
- A custom application class has been introduced to manage and provide the CredentialsManager instance.
- Navigation between Recipes and Login fragments happens solely through emissions from CredentialsManager.